### PR TITLE
changing faraday dependency to allow any minor version bump

### DIFF
--- a/behance.gemspec
+++ b/behance.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency     'faraday',            '~> 0.8.4'
+  gem.add_runtime_dependency     'faraday',            '~> 0.8'
   gem.add_runtime_dependency     'faraday_middleware', '~> 0.8'
   gem.add_runtime_dependency     'json',               '~> 1.8.1'
   gem.add_development_dependency 'webmock',            '~> 1.8.10'


### PR DESCRIPTION
This gem has a conflict with omniauth-oauth2 gem.
