### PR TITLE
Fix `stub! is deprecated` warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 master
 ===
-...
+* Fix `stub! is deprecated` warning.
 
 0.6.0
 ===

--- a/spec/behance/collections_spec.rb
+++ b/spec/behance/collections_spec.rb
@@ -78,7 +78,7 @@ describe Behance::Client::Collections do
 
     context "with parameters" do
       before do
-        @options.stub!(page: 1, time: Time.new)
+        @options.stub(page: 1, time: Time.new)
         stub_get("collections/1/projects").with(query: @options).
           to_return(body: fixture("collection_projects.json"))
       end

--- a/spec/behance/user_spec.rb
+++ b/spec/behance/user_spec.rb
@@ -78,7 +78,7 @@ describe Behance::Client::User do
 
     context "with parameters" do
       before do
-        @options.stub!(page: 1, time: Time.new)
+        @options.stub(page: 1, time: Time.new)
         stub_get("users/1/projects").with(query: @options).
           to_return(body: fixture("user_projects.json"))
       end


### PR DESCRIPTION
As recommended by rspec:
`stub! is deprecated. Use stub instead.`